### PR TITLE
Add option to explicitly specify dependencies to report

### DIFF
--- a/src/main/kotlin/com/jaredsburrows/license/LicensePlugin.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/LicensePlugin.kt
@@ -47,6 +47,7 @@ class LicensePlugin : Plugin<Project> {
       jsonFile = File(path + LicenseReportTask.JSON_EXT)
       generateHtmlReport = extension.generateHtmlReport
       generateJsonReport = extension.generateJsonReport
+      explicitDependencies = extension.explicitDependencies
       copyHtmlReportToAssets = false
       copyJsonReportToAssets = false
     }
@@ -72,6 +73,7 @@ class LicensePlugin : Plugin<Project> {
         generateJsonReport = extension.generateJsonReport
         copyHtmlReportToAssets = extension.copyHtmlReportToAssets
         copyJsonReportToAssets = extension.copyJsonReportToAssets
+        explicitDependencies = extension.explicitDependencies
         assetDirs = (project
           .extensions
           .getByName("android") as BaseExtension)

--- a/src/main/kotlin/com/jaredsburrows/license/LicenseReportExtension.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/LicenseReportExtension.kt
@@ -19,4 +19,9 @@ open class LicenseReportExtension { // extensions can't be final
    * project is not an Android project. Has no effect if the JSON report is disabled.
    */
   var copyJsonReportToAssets = false
+
+  /**
+   * Explicit dependencies or `null` to fetch dynamically.
+   */
+  var explicitDependencies: List<String>? = null
 }

--- a/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/internal/report/HtmlReport.kt
@@ -111,7 +111,6 @@ class HtmlReport(private val projects: List<Project>) {
                 li {
                   a(href = "#$currentLicense") {
                     +project.name
-                    +" (${project.version})"
                   }
                   val copyrightYear = if (project.year.isEmpty()) DEFAULT_YEAR else project.year
                   dl {

--- a/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -203,12 +203,12 @@ final class LicensePluginAndroidSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">appcompat-v7 (26.1.0)</a>
+            <li><a href="#1934118923">appcompat-v7</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -318,7 +318,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -417,12 +417,12 @@ final class LicensePluginAndroidSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">appcompat-v7 (26.1.0)</a>
+            <li><a href="#1934118923">appcompat-v7</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -550,22 +550,22 @@ final class LicensePluginAndroidSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">appcompat-v7 (26.1.0)</a>
+            <li><a href="#1934118923">appcompat-v7</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">support-annotations (26.1.0)</a>
+            <li><a href="#1934118923">support-annotations</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">support-v4 (26.1.0)</a>
+            <li><a href="#1934118923">support-v4</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -762,7 +762,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -771,7 +771,7 @@ final class LicensePluginAndroidSpec extends Specification {
             <pre>${myGetLicenseText('apache-2.0.txt')}</pre>
       <br>
             <hr>
-            <li><a href="#1783810846">Android GIF Drawable Library (1.2.3)</a>
+            <li><a href="#1783810846">Android GIF Drawable Library</a>
               <dl>
                 <dt>Copyright &copy; 20xx Karol WrXXtniak</dt>
               </dl>
@@ -879,7 +879,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#0">Fake dependency name (1.0.0)</a>
+            <li><a href="#0">Fake dependency name</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
               </dl>
@@ -982,7 +982,7 @@ final class LicensePluginAndroidSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -991,7 +991,7 @@ final class LicensePluginAndroidSpec extends Specification {
             <pre>${myGetLicenseText('apache-2.0.txt')}</pre>
       <br>
             <hr>
-            <li><a href="#-296292112">Fake dependency name (1.0.0)</a>
+            <li><a href="#-296292112">Fake dependency name</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
               </dl>

--- a/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicensePluginAndroidSpec.groovy
@@ -269,6 +269,101 @@ final class LicensePluginAndroidSpec extends Specification {
     taskName << ['licenseDebugReport', 'licenseReleaseReport']
   }
 
+  @Unroll def '#taskName with explicit dependencies'() {
+    given:
+    buildFile <<
+      """
+      buildscript {
+        dependencies {
+          classpath files($classpathString)
+        }
+      }
+
+      repositories {
+        maven {
+          url '${mavenRepoUrl}'
+        }
+      }
+
+      apply plugin: 'com.android.application'
+      apply plugin: 'com.jaredsburrows.license'
+
+      android {
+        compileSdkVersion 28
+
+        defaultConfig {
+          applicationId 'com.example'
+        }
+      }
+
+      dependencies {
+        implementation 'com.android.support:design:26.1.0'
+      }
+
+      licenseReport {
+        explicitDependencies = ['com.android.support:design:26.1.0']
+      }
+      """
+
+    when:
+    def result = gradleWithCommand(testProjectDir.root, "${taskName}", '-s')
+    def actualHtml = new File("${reportFolder}/${taskName}.html").text
+    def expectedHtml =
+      """
+      <html>
+        <head>
+          <style>body { font-family: sans-serif } pre { background-color: #eeeeee; padding: 1em; white-space: pre-wrap; display: inline-block }</style>
+          <title>Open source licenses</title>
+        </head>
+        <body>
+          <h3>Notice for packages:</h3>
+          <ul>
+            <li><a href="#1934118923">design (26.1.0)</a>
+              <dl>
+                <dt>Copyright &copy; 20xx The original author or authors</dt>
+              </dl>
+            </li>
+      <a name="1934118923"></a>
+            <pre>${myGetLicenseText('apache-2.0.txt')}</pre>
+      <br>
+            <hr>
+          </ul>
+        </body>
+      </html>
+      """
+    def actualJson = new File("${reportFolder}/${taskName}.json").text
+    def expectedJson =
+      """
+      [
+        {
+          "project": "design",
+          "description": null,
+          "version": "26.1.0",
+          "developers": [],
+          "url": null,
+          "year": null,
+          "licenses": [
+            {
+              "license": "The Apache Software License",
+              "license_url": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+          ],
+          "dependency": "com.android.support:design:26.1.0"
+        }
+      ]
+      """
+
+    then:
+    result.task(":${taskName}").outcome == SUCCESS
+    result.output.find("Wrote HTML report to .*${reportFolder}/${taskName}.html.")
+    result.output.find("Wrote JSON report to .*${reportFolder}/${taskName}.json.")
+    assertHtml(expectedHtml, actualHtml)
+    assertJson(expectedJson, actualJson)
+
+    where:
+    taskName << ['licenseDebugReport', 'licenseReleaseReport']
+  }
+
   @Unroll def '#taskName with buildTypes'() {
     given:
     buildFile <<

--- a/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/LicensePluginJavaSpec.groovy
@@ -135,7 +135,7 @@ final class LicensePluginJavaSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#0">firebase-core (10.0.1)</a>
+            <li><a href="#0">firebase-core</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -207,12 +207,12 @@ final class LicensePluginJavaSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">appcompat-v7 (26.1.0)</a>
+            <li><a href="#1934118923">appcompat-v7</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -355,7 +355,7 @@ final class LicensePluginJavaSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#-296292112">Fake dependency name (1.0.0)</a>
+            <li><a href="#-296292112">Fake dependency name</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
               </dl>
@@ -434,7 +434,7 @@ final class LicensePluginJavaSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1195092182">Fake dependency name (1.0.0)</a>
+            <li><a href="#1195092182">Fake dependency name</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
               </dl>
@@ -521,7 +521,7 @@ final class LicensePluginJavaSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">Retrofit (2.3.0)</a>
+            <li><a href="#1934118923">Retrofit</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -530,7 +530,7 @@ final class LicensePluginJavaSpec extends Specification {
             <pre>${myGetLicenseText('apache-2.0.txt')}</pre>
       <br>
             <hr>
-            <li><a href="#-296292112">Fake dependency name (1.0.0)</a>
+            <li><a href="#-296292112">Fake dependency name</a>
               <dl>
                 <dt>Copyright &copy; 2017 name</dt>
               </dl>
@@ -639,12 +639,12 @@ final class LicensePluginJavaSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">appcompat-v7 (26.1.0)</a>
+            <li><a href="#1934118923">appcompat-v7</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
@@ -750,12 +750,12 @@ final class LicensePluginJavaSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#1934118923">appcompat-v7 (26.1.0)</a>
+            <li><a href="#1934118923">appcompat-v7</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>
             </li>
-            <li><a href="#1934118923">design (26.1.0)</a>
+            <li><a href="#1934118923">design</a>
               <dl>
                 <dt>Copyright &copy; 20xx The original author or authors</dt>
               </dl>

--- a/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
+++ b/src/test/groovy/com/jaredsburrows/license/internal/report/HtmlReportSpec.groovy
@@ -70,13 +70,13 @@ final class HtmlReportSpec extends Specification {
         <body>
           <h3>Notice for packages:</h3>
           <ul>
-            <li><a href="#87638953">name ()</a>
+            <li><a href="#87638953">name</a>
               <dl>
                 <dt>Copyright &copy; year name</dt>
                 <dt>Copyright &copy; year name</dt>
               </dl>
             </li>
-            <li><a href="#87638953">name ()</a>
+            <li><a href="#87638953">name</a>
               <dl>
                 <dt>Copyright &copy; year name</dt>
                 <dt>Copyright &copy; year name</dt>
@@ -87,7 +87,7 @@ final class HtmlReportSpec extends Specification {
       <a href="url">url</a></pre>
       <br>
             <hr>
-            <li><a href="#0">name ()</a>
+            <li><a href="#0">name</a>
               <dl>
                 <dt>Copyright &copy; year name</dt>
                 <dt>Copyright &copy; year name</dt>


### PR DESCRIPTION
Usage: Set `explicitDependencies` property in the configuration block.

Also, omit versions from the report.