### PR TITLE
Fix ConcurrentModificationException in broad scan

### DIFF
--- a/src/main/kotlin/com/jaredsburrows/license/Project.kt
+++ b/src/main/kotlin/com/jaredsburrows/license/Project.kt
@@ -238,7 +238,7 @@ private fun Project.buildPomInput(
       val broadComponents = linkedSetOf<ModuleComponentIdentifier>()
       val allProjects = rootProject.allprojects
       for (proj in allProjects) {
-        for (config in proj.configurations) {
+        for (config in proj.configurations.toList()) {
           if (!config.isCanBeResolved) continue
           try {
             config.incoming.resolutionResult.allComponents


### PR DESCRIPTION
## Summary
- Snapshot `proj.configurations` with `.toList()` before iterating in the broad scan loop to prevent `ConcurrentModificationException`
- AGP 8.11.1 dynamically adds configurations during Gradle's configuration phase, which mutates the collection while the broad scan iterates over it
- This fixes the CI failure on `android-host-android-library-unit-tests` in [software PR #32641](https://github.com/ButterflyNetwork/software/pull/32641)

## Test plan
- [ ] Verify `./gradlew app:licenseArm64v8aStoreReport` completes without error
- [ ] Verify CI passes on the parent Kotlin upgrade PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)