### PR TITLE
Dedupe license report entries by group:artifact

### DIFF
--- a/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
+++ b/gradle-license-plugin/src/main/kotlin/com/jaredsburrows/license/LicenseReportTask.kt
@@ -163,7 +163,7 @@ internal abstract class LicenseReportTask
     ) {
       rootCoordinates
         .asSequence()
-        .distinct()
+        .distinctBy { parseCoordinate(it).let { (group, artifact, _) -> "$group:$artifact" } }
         .mapNotNull { coordinate ->
           val pomFilePath = pomCoordinatesToFile[coordinate] ?: return@mapNotNull null
           coordinate to File(pomFilePath)


### PR DESCRIPTION
## Summary

`generatePOMInfo` deduplicates `rootCoordinates` with `.distinct()`, which keys off the full Maven coordinate (`group:artifact:version`). When two versions of the same artifact resolve into a build (e.g. a transitive `1.x` alongside a direct `2.x` request), the report ends up with two entries for the same library.

Two versions of the same artifact share the same license, so dedupe on `(group, artifact)` instead.
